### PR TITLE
Fixed bug reported in Issue #3.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # `aflow` Revision History
 
+## Revision 0.0.9
+
+- Fixed a bug that prevented "bz2" and "png" files from being downloaded.
+
 ## Revision 0.0.8
 
 - Fixed a bug that showed the wrong number of configs for `__len__` when slices are used.

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -13,7 +13,7 @@ def test_eq_hash(paper):
 
 def test_files(paper, tmpdir):
     from aflow.entries import AflowFile
-    from os import path
+    from os import path, remove
     a = paper[0]
     assert isinstance(a.files, list)
     assert len(a.files) > 0
@@ -27,6 +27,17 @@ def test_files(paper, tmpdir):
 
     with pytest.raises(KeyError):
         a.files["dummy"]
+
+    a = AflowFile('aflowlib.duke.edu:AFLOWDATA/ICSD_WEB/FCC/Be1O1_ICSD_163467',
+                  'EIGENVAL.bands.bz2')
+    a.__call__()
+
+    target = path.abspath(path.expanduser('EIGENVAL.bands.bz2'))
+    assert path.isfile(target)
+    remove(target)
+    target = str(tmpdir.join("eigenval.bz2"))
+    a.__call__(target)
+    assert path.isfile(target)    
     
 def test_atoms(paper):
     from aflow import K


### PR DESCRIPTION
When a user is requesting a file that can't be decoded, i.e., a bz2 file, and displayed on the screen the previous code would throw an error. Now the url request is wrapped in a try block so that if the file can't be decoded it is dowloaded and saved to the hard drive instead.