### PR TITLE
Remove argparse from the dependencies 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-argparse
 pypandoc
 termcolor
 numpy

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='aflow',
       setup_requires=['pytest-runner',],
       tests_require=['pytest', 'python-coveralls'],
       install_requires=[
-          "argparse",
           "termcolor",
           "numpy",
           "six",


### PR DESCRIPTION
I do not think there is a need to support Python < 2.7 or < 3.2.
https://pypi.org/project/argparse/
> As of Python >= 2.7 and >= 3.2, the argparse module is maintained within the Python standard library. For users who still need to support Python < 2.7 or < 3.2, it is also provided as a separate package, which tries to stay compatible with the module in the standard library, but also supports older Python versions.